### PR TITLE
Fix PS-OCT signal

### DIFF
--- a/polarization/jonesmatrix.py
+++ b/polarization/jonesmatrix.py
@@ -75,7 +75,7 @@ You cannot obtain the values without providing a wavevector k or the matrix itse
 
         backward = JonesMatrix(m=self.m.T,
                                physicalLength=self.L,
-                               orientation=self.orientation)
+                               orientation=0)
         backward.b3 = -backward.b3
         backward.b2 = -backward.b2
         backward.orientation = -backward.orientation
@@ -427,7 +427,8 @@ class BirefringentMaterial(JonesMatrix):
             explicit = JonesMatrix(A=1, B=0, C=0, D=exp(1j * phi), physicalLength=self.L)
             explicit.orientation = self.orientation
             if self.isBackward:
-                explicit = JonesMatrix(m=explicit.m.T, physicalLength=self.L, orientation=-self.orientation)
+                explicit = JonesMatrix(m=explicit.m.T, physicalLength=self.L,
+                                       orientation=0)
                 explicit.b3 = -explicit.b3
                 explicit.b2 = -explicit.b2
             return explicit.computeMatrix()
@@ -452,7 +453,8 @@ class Vacuum(JonesMatrix):
             explicit = JonesMatrix(A=exp(1j * k * self.L), B=0, C=0, D=exp(1j * k * self.L), physicalLength=self.L)
             explicit.orientation = self.orientation
             if self.isBackward:
-                explicit = JonesMatrix(m=explicit.m.T, physicalLength=self.L, orientation=-self.orientation)
+                explicit = JonesMatrix(m=explicit.m.T, physicalLength=self.L,
+                                       orientation=0)
                 explicit.b3 = -explicit.b3
                 explicit.b2 = -explicit.b2
             return explicit.computeMatrix()

--- a/polarization/jonesmatrix.py
+++ b/polarization/jonesmatrix.py
@@ -423,8 +423,9 @@ class BirefringentMaterial(JonesMatrix):
 
     def computeMatrix(self, k=None):
         if k is not None:
-            phi = k * self.deltaIndex * self.L
-            explicit = JonesMatrix(A=1, B=0, C=0, D=exp(1j * phi), physicalLength=self.L)
+            phi = k * self.L
+            deltaPhi = k * self.deltaIndex * self.L
+            explicit = JonesMatrix(A=exp(1j * phi), B=0, C=0, D=exp(1j * (deltaPhi + phi)), physicalLength=self.L)
             explicit.orientation = self.orientation
             if self.isBackward:
                 explicit = JonesMatrix(m=explicit.m.T, physicalLength=self.L,

--- a/polarization/pulse.py
+++ b/polarization/pulse.py
@@ -161,7 +161,7 @@ class PulseCollection:
     def display(self):
         fig, axes = plt.subplots(1, 4)
         for i, ax in enumerate(axes):
-            ax.imshow(np.transpose(self.intensity[i]))
+            ax.imshow(np.transpose(self.intensity[i]), aspect='auto', cmap='gray')
         plt.show()
 
     @classmethod

--- a/polarization/tests/testsTissue.py
+++ b/polarization/tests/testsTissue.py
@@ -1,10 +1,8 @@
 import envtest
-import numpy as np
 from polarization.tissue import *
 from polarization.tissueStack import *
 from polarization.tissueLayer import *
 from polarization.pulse import *
-import matplotlib.pyplot as plt
 
 np.random.seed(521)
 
@@ -17,28 +15,18 @@ class TestTissue(envtest.MyTestCase):
         tissue = RandomTissue2D(nLayers=6)
         self.assertEqual(tissue.map.shape, (7, 200))
 
-    def testTissueStackAt(self):
-        tissue = RandomTissue2D(nLayers=6)
-
-        stack = tissue.stackAt(5)
-        self.assertAlmostEqual(len(stack), 6)
-
     def testPSOCT(self):
-        # 103 seconds at res = 100, scat = 100*10 ?, 330s at 512 res
         resolution = 50
         centerWavelength = 1.3
         bandwidth = 0.13
 
-        tissue = TissueTestUnit()  # 105s
+        tissue = TissueTestUnit()
         pIn = PulseCollection.dualInputStates(centerWavelength, bandwidth, resolution=resolution)
 
         # fixme: The computations are way too slow (x400 ish). Parallelization will be required.
         #  All objects are currently immutable.
         pOut = tissue.scan(pIn, verbose=True)
-
         pOut.display()
-
-        # fixme Tissue.stackAt :  use the same scatterer at each position
 
 
 class TissueTestUnit(RandomTissue2D):
@@ -46,3 +34,7 @@ class TissueTestUnit(RandomTissue2D):
         layers = [TissueLayer(0.004, (0, 1, 0), 20, 80), TissueLayer(0.004, (1, 0, 0), 1, 80)]
         testStack = TissueStack(offset=80, layers=layers)
         super(TissueTestUnit, self).__init__(referenceStack=testStack, width=2, flat=True)
+
+
+if __name__ == '__main__':
+    envtest.main()

--- a/polarization/tests/testsTissue.py
+++ b/polarization/tests/testsTissue.py
@@ -1,6 +1,8 @@
 import envtest
 import numpy as np
 from polarization.tissue import *
+from polarization.tissueStack import *
+from polarization.tissueLayer import *
 from polarization.pulse import *
 import matplotlib.pyplot as plt
 
@@ -22,11 +24,12 @@ class TestTissue(envtest.MyTestCase):
         self.assertAlmostEqual(len(stack), 6)
 
     def testPSOCT(self):
-        resolution = 20
+        # 103 seconds at res = 100, scat = 100*10 ?, 330s at 512 res
+        resolution = 50
         centerWavelength = 1.3
         bandwidth = 0.13
 
-        tissue = RandomTissue2D(width=2, surface=False, nLayers=1, layerHeightRange=(100, 110), offset=200)
+        tissue = TissueTestUnit()  # 105s
         pIn = PulseCollection.dualInputStates(centerWavelength, bandwidth, resolution=resolution)
 
         # fixme: The computations are way too slow (x400 ish). Parallelization will be required.
@@ -34,3 +37,12 @@ class TestTissue(envtest.MyTestCase):
         pOut = tissue.scan(pIn, verbose=True)
 
         pOut.display()
+
+        # fixme Tissue.stackAt :  use the same scatterer at each position
+
+
+class TissueTestUnit(RandomTissue2D):
+    def __init__(self):
+        layers = [TissueLayer(0.004, (0, 1, 0), 20, 80), TissueLayer(0.004, (1, 0, 0), 1, 80)]
+        testStack = TissueStack(offset=80, layers=layers)
+        super(TissueTestUnit, self).__init__(referenceStack=testStack, width=2, flat=True)

--- a/polarization/tissue.py
+++ b/polarization/tissue.py
@@ -49,6 +49,7 @@ class Tissue:
         layers = []
         for L, layer in zip(line[1:], self.referenceStack):
             layer.thickness = L
+            layer.scatterers.resetScatterers()  # fixme: use the same scatterer at each position
             layers.append(layer)
 
         return TissueStack(offset=line[0], layers=layers)

--- a/polarization/tissue.py
+++ b/polarization/tissue.py
@@ -1,5 +1,6 @@
 from .tissueStack import *
 from .pulse import *
+from copy import deepcopy
 from typing import Union
 import numpy as np
 
@@ -9,12 +10,14 @@ __all__ = ['Tissue', 'RandomTissue2D']
 class Tissue:
     def __init__(self, referenceStack=None, height=3000, width=200, depth=1):
         # todo: change shape dims to microns
+        # todo: allow 3D tissue
         self.height = height
         self.width = width
         self.depth = depth
         self.map = None
 
         self.referenceStack = referenceStack
+        self.stacks = []
 
     @property
     def referenceStack(self):
@@ -33,26 +36,19 @@ class Tissue:
     def nLayers(self):
         return len(self.referenceStack)
 
-    def generateMap(self):
-        # overwrite
-        pass
-
-    def stackAt(self, coordinates) -> TissueStack:
-        """ Tissue Stack of an A-Line at a specified location. """
-        if type(coordinates) is int:
-            line = self.map[:, coordinates]
-        elif len(coordinates) == 2:
-            line = self.map[:, coordinates[0], coordinates[1]]
-        else:
-            raise ValueError
-
+    def _stackOf(self, lineData):
         layers = []
-        for L, layer in zip(line[1:], self.referenceStack):
+        for L, layer in zip(lineData[1:], deepcopy(self.referenceStack.layers)):
             layer.thickness = L
-            layer.scatterers.resetScatterers()  # fixme: use the same scatterer at each position
+            layer.scatterers.resetScatterers()
             layers.append(layer)
 
-        return TissueStack(offset=line[0], layers=layers)
+        return TissueStack(offset=lineData[0], layers=layers)
+
+    def generateStacks(self):
+        for w in range(self.width):
+            line = self.map[:, w]
+            self.stacks.append(self._stackOf(line))
 
     def scan(self, pulse: Union[Pulse, PulseCollection], verbose=False):
         if verbose:
@@ -73,7 +69,7 @@ class Tissue:
         bScan = []
         for b in range(self.width):
             v_print(" .Stack {}/{}".format(b+1, self.width))
-            bScan.append(self.stackAt(b).backscatterMany(pulse))
+            bScan.append(self.stacks[b].backscatterMany(pulse))
         return PulseArray(bScan)
 
     def _scanPulseCollection(self, pulses, v_print) -> PulseCollection:
@@ -86,16 +82,7 @@ class Tissue:
         return PulseCollection(pulsesOut)
 
     def __iter__(self):
-        self.n = 0
-        return self
-
-    def __next__(self) -> TissueStack:
-        if self.n < self.width:  # fixme: iteration only works for 2D tissue
-            stack = self.stackAt(self.n)
-            self.n += 1
-            return stack
-        else:
-            raise StopIteration
+        return iter(self.stacks)
 
     def display(self):
         """ Display all layer stacks and their properties. """
@@ -114,6 +101,7 @@ class RandomTissue2D(Tissue):
         super(RandomTissue2D, self).__init__(referenceStack=referenceStack, height=height, width=width, depth=1)
 
         self.generateMap(flat)
+        self.generateStacks()
 
     def generateMap(self, flat=False):
         initialLengths = [self.referenceStack.offset, *[layer.thickness for layer in self.referenceStack]]

--- a/polarization/tissue.py
+++ b/polarization/tissue.py
@@ -103,7 +103,7 @@ class Tissue:
 
 class RandomTissue2D(Tissue):
     def __init__(self, height=3000, width=200,
-                 referenceStack=None,
+                 referenceStack=None, flat=False,
                  surface=False, maxBirefringence=0.0042, nLayers=None, offset=None, layerHeightRange=(60, 400)):
 
         if referenceStack is None:
@@ -112,15 +112,20 @@ class RandomTissue2D(Tissue):
 
         super(RandomTissue2D, self).__init__(referenceStack=referenceStack, height=height, width=width, depth=1)
 
-        self.generateMap()
+        self.generateMap(flat)
 
-    def generateMap(self):
-        offSets = [RandomSinusGroup(maxA=10, minF=0.001, maxF=0.1, n=40)]
-        offSets.extend([RandomSinusGroup(maxA=2, minF=0.01, maxF=0.1, n=5) for _ in range(self.nLayers)])
+    def generateMap(self, flat=False):
         initialLengths = [self.referenceStack.offset, *[layer.thickness for layer in self.referenceStack]]
 
-        for i, (L, dL) in enumerate(zip(initialLengths, offSets)):
-            self.map[i] = np.array(L + dL.eval(np.arange(self.width)), dtype=int)
+        if not flat:
+            offSets = [RandomSinusGroup(maxA=5, minF=0.001, maxF=0.1, n=40)]
+            offSets.extend([RandomSinusGroup(maxA=2, minF=0.01, maxF=0.1, n=5) for _ in range(self.nLayers)])
+
+            for i, (L, dL) in enumerate(zip(initialLengths, offSets)):
+                self.map[i] = np.array(L + dL.eval(np.arange(self.width)), dtype=int)
+        else:
+            for i, L in enumerate(initialLengths):
+                self.map[i] = np.full(self.width, L, dtype=int)
 
 
 class Sinus:

--- a/polarization/tissueLayer.py
+++ b/polarization/tissueLayer.py
@@ -47,11 +47,8 @@ class TissueLayer:
 
     def transferMatrix(self, dz=None) -> BirefringentMaterial:
         if dz is None:
-            return BirefringentMaterial(deltaIndex=self.birefringence, fastAxisOrientation=self.orientation,
-                                        physicalLength=self.thickness)
-        else:
-            return BirefringentMaterial(deltaIndex=self.birefringence, fastAxisOrientation=self.orientation,
-                                        physicalLength=dz)
+            dz = self.thickness
+        return BirefringentMaterial(deltaIndex=self.birefringence, fastAxisOrientation=self.orientation, physicalLength=dz)
 
     def propagateThrough(self, vector: JonesVector) -> JonesVector:
         return self.transferMatrix() * vector

--- a/polarization/tissueStack.py
+++ b/polarization/tissueStack.py
@@ -27,7 +27,6 @@ class TissueStack:
         return iter(self.layers)
 
     def transferMatrix(self, layerIndex=None, backward=False):
-        # todo: this is missing the initial propagation in 'vacuum' with L=offset
         M = JonesMatrix(1, 0, 0, 1)
         if backward:
             backwardLayers = self.layers[:layerIndex]


### PR DESCRIPTION
- **Add absolute phase term (e^ikz)  in BirefringentMaterial matrix. This solves the main signal problem. (Edit: also confirmed with Martin that this is the right definition in our case).**
- Create all tissue stacks at tissue init so we can re-use the same scatterer distribution at a given position when different pulses ask for it. 
- Set jonesMatrix.backward orientation to 0 since we create it with self.m.T where self.m has already been rotated. 

Example: intensity display of the fringes (Ex and Ey) for two input polarization states (`TestTissue.testPSOCT()` with resolution=128 and width=20 ... this took 37 minutes)
![image](https://user-images.githubusercontent.com/29587649/115169289-9a074c80-a08b-11eb-867b-5e97e2239505.png)

Next problem to tackle is speed. 