### PR TITLE
1.Optimize backscattering matrix

### DIFF
--- a/polarization/tests/testsTissue.py
+++ b/polarization/tests/testsTissue.py
@@ -31,7 +31,7 @@ class TestTissue(envtest.MyTestCase):
             self.assertFalse(EyIsAllZeros)
 
     def testPSOCT(self):
-        resolution = 50
+        resolution = 100
         centerWavelength = 1.3
         bandwidth = 0.13
 
@@ -44,9 +44,9 @@ class TestTissue(envtest.MyTestCase):
 
 class TissueTestUnit(RandomTissue2D):
     def __init__(self):
-        layers = [TissueLayer(0.004, (0, 1, 0), 20, 80), TissueLayer(0.004, (1, 0, 0), 1, 80)]
-        testStack = TissueStack(offset=80, layers=layers)
-        super(TissueTestUnit, self).__init__(referenceStack=testStack, width=2, flat=True)
+        layers = [TissueLayer(0.004, (0, 1, 0), 20, 160), TissueLayer(0.004, (1, 0, 0), 1, 160)]
+        testStack = TissueStack(offset=160, layers=layers)
+        super(TissueTestUnit, self).__init__(referenceStack=testStack, width=4, flat=True)
 
 
 if __name__ == '__main__':

--- a/polarization/tissueLayer.py
+++ b/polarization/tissueLayer.py
@@ -51,8 +51,8 @@ class TissueLayer:
         return BirefringentMaterial(deltaIndex=self.birefringence, fastAxisOrientation=self.orientation, physicalLength=dz)
 
     def backscatterTransferMatrix(self, k):
-        A = np.sum([scat.strength * exp(1j * 2 * scat.dz * k) for scat in self.scatterers])
-        D = np.sum([scat.strength * exp(1j * 2 * scat.dz * k * (1 + self.birefringence)) for scat in self.scatterers])
+        A = sum([scat.strength * exp(1j * 2 * scat.dz * k) for scat in self.scatterers])
+        D = sum([scat.strength * exp(1j * 2 * scat.dz * k * (1 + self.birefringence)) for scat in self.scatterers])
         return JonesMatrix(A=A, B=0, C=0, D=D, orientation=self.orientation)
 
     def propagateThrough(self, vector: JonesVector) -> JonesVector:

--- a/polarization/tissueLayer.py
+++ b/polarization/tissueLayer.py
@@ -62,7 +62,9 @@ class TissueLayer:
     def backscatter(self, vector: JonesVector) -> JonesVector:
         signal = JonesVector(0, 0, k=vector.k)
         for scat in self.scatterers:
-            scatSignal = self.transferMatrix(dz=2*scat.dz) * vector * scat.strength
+            if scat.transferMatrix is None:
+                scat.transferMatrix = self.transferMatrix(dz=2 * scat.dz)
+            scatSignal = scat.transferMatrix * vector * scat.strength
             signal += scatSignal
         return signal
 
@@ -81,6 +83,7 @@ class Scatterer:
     def __init__(self, max_dz):
         self.dz = np.random.rand() * max_dz
         self.strength = np.random.rand()
+        self.transferMatrix = None
 
 
 class ScattererGroup:

--- a/polarization/vector.py
+++ b/polarization/vector.py
@@ -194,7 +194,7 @@ class Vector:
         return Vector(uy*vz - uz*vy, uz*vx - ux*vz, ux*vy - uy*vx)
 
     def dot(self, vector):
-        return self.x*vector.x + self.y*vector.y + self.z*vector.z 
+        return self._x*vector._x + self._y*vector._y + self._z*vector._z 
 
     def normalizedCrossProduct(self, vector) -> 'Vector':
         """ Computes the normalized cross product with another vector.


### PR DESCRIPTION
1st optimization

Changes 

- JonesVector: Explicit variable access to accelerate dot product (11% faster)
- TissueLayer: create a single backscatter Transfer Matrix for all scatterers (around **20x faster**), but for a single wavelength at a time